### PR TITLE
CAT-795: Fetch Data via filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+---
+
+All notable changes to this project will be documented in this file.
+
+According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unreleased` section serves the following purposes:
+
+-   People can see what changes they might expect in upcoming releases.
+-   At release time, you can move the `Unreleased` section changes into a new release version section.
+
+## Types of changes
+
+---
+
+-   `Added` for new features.
+-   `Changed` for changes in existing functionality.
+-   `Removed` for now removed features.
+-   `Fixed` for any bug fixes.
+-   `Security` in case of vulnerabilities.
+-   `Deprecated` for soon-to-be removed features.
+
+## Unreleased
+---
+
+
+### Added
+- [#4](https://github.com/FC4E-CAT/fc4e-cat-api-kb/pull/4) CAT-826: [KB] Database Setup & Implement Example Views
+
+
+### Fix
+- [#5](https://github.com/FC4E-CAT/fc4e-cat-api-kb/pull/5)CAT-826: [KB] Database Setup & Implement Example Views (add views)
+
+
+### Removed
+

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,21 @@
             <version>1.18.32</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/grnet/knowledgebase/api/entity/relation/ProviderAuthority.java
+++ b/src/main/java/org/grnet/knowledgebase/api/entity/relation/ProviderAuthority.java
@@ -7,7 +7,7 @@ import org.grnet.knowledgebase.api.entity.Authority;
 import org.grnet.knowledgebase.api.entity.Provider;
 
 @Entity
-@Table(name = "k_Manager_Provider")
+@Table(name = "k_Provider_Authority")
 public class ProviderAuthority extends PanacheEntityBase {
 
     @EmbeddedId

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ManagerProviderResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ManagerProviderResource.java
@@ -2,9 +2,7 @@ package org.grnet.knowledgebase.api.graphql;
 
 import io.quarkus.panache.common.Page;
 import jakarta.annotation.security.RolesAllowed;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.Identifier;
 import org.grnet.knowledgebase.api.entity.Manager;
 import org.grnet.knowledgebase.api.entity.relation.ManagerProvider;
@@ -30,8 +28,15 @@ public class ManagerProviderResource {
 
     @Query("identifiers")
     @Description("Fetches a paginated list of identifiers")
-    public List<Identifier> getPaginatedIdentifiers(@Description("Page number to fetch") int page,
-                                                    @Description("Number of items per page") int size) {
+    public List<Identifier> getPaginatedIdentifiers(
+            @Name("page")
+            @Description("Page number to fetch")
+            @DefaultValue("1")
+            int page,
+            @Name("size")
+            @Description("Number of items per page")
+            @DefaultValue("10")
+            int size) {
         return Identifier
                 .findAll()
                 .page(Page.of(page, size))

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/PropertiesStackCombinedResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/PropertiesStackCombinedResource.java
@@ -2,9 +2,7 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.PropertiesStackCombined;
 import org.grnet.knowledgebase.api.repository.PropertiesStackCombinedRepository;
 
@@ -18,19 +16,37 @@ public class PropertiesStackCombinedResource {
     PropertiesStackCombinedRepository repository;
 
     @Query("getPropertiesStackCombined")
+    @Description("Fetches combined properties from the database.")
     public List<PropertiesStackCombined> getPropertiesStackCombined() {
         return repository.listAll();
     }
 
     @Query("getPropertiesStackCombinedByLabel")
-    public List<PropertiesStackCombined> getPropertiesStackCombinedByLabel(String label) {
+    @Description("Fetches a list of combined (static, dynamic) properties by label")
+    public List<PropertiesStackCombined> getPropertiesStackCombinedByLabel(
+            @Name("label")
+            @Description("The label of the Property")
+            String label) {
         return repository.findByPropertyLabel(label);
     }
 
+    @Query("searchPropertiesStackCombinedStack")
+    @Description("Fetches a list of properties stacks combined by search")
+    public List<PropertiesStackCombined> searchPropertiesStackCombined(
+            @Name("search")
+            @Description("Search by lodIDN, labelIdentifier, value") String search) {
+        return repository.searchByKeyword(search);
+    }
+
     @Query("getPropertiesStackCombinedPaged")
+    @Description("Fetches a paginated list of the combined (static, dynamic) properties")
     public List<PropertiesStackCombined> getPropertiesStackCombinedPaged(
-            @Description("Page number to fetch") int page,
-            @Description("Number of items per page") int size){
+            @Name("Page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.") int page,
+            @Name("Size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.") int size){
         return repository.findByPage(page, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/PropertiesStackDynamicResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/PropertiesStackDynamicResource.java
@@ -2,9 +2,7 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.PropertiesStackDynamic;
 import org.grnet.knowledgebase.api.repository.PropertiesStackDynamicRepository;
 
@@ -18,19 +16,29 @@ public class PropertiesStackDynamicResource {
     PropertiesStackDynamicRepository repository;
 
     @Query("getPropertiesStackDynamic")
+    @Description("Fetches properties from the database.")
     public List<PropertiesStackDynamic> getPropertiesStackDynamic() {
         return repository.listAll();
     }
 
     @Query("getPropertiesStackDynamicByLabel")
-    public List<PropertiesStackDynamic> getPropertiesStackDynamicByLabel(String label) {
+    @Description("Fetches a list of dynamic properties by label")
+    public List<PropertiesStackDynamic> getPropertiesStackDynamicByLabel(
+            @Name("label")
+            @Description("The label of the Property")
+            String label) {
         return repository.findByPropertyLabel(label);
     }
 
     @Query("getPropertiesStackDynamicPaged")
+    @Description("Fetches a paginated list of dynamic properties")
     public List<PropertiesStackDynamic> getPropertiesStackDynamicPaged(
-            @Description("Page number to fetch") int page,
-            @Description("Number of items per page") int size){
+            @Name("page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.") int page,
+            @Name("size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.") int size){
         return repository.findByPage(page, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/PropertiesStackStaticResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/PropertiesStackStaticResource.java
@@ -2,9 +2,7 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.PropertiesStackStatic;
 import org.grnet.knowledgebase.api.repository.PropertiesStackStaticRepository;
 
@@ -18,19 +16,29 @@ public class PropertiesStackStaticResource {
     PropertiesStackStaticRepository repository;
 
     @Query("getPropertiesStackStatic")
+    @Description("Fetches static properties from the database.")
     public List<PropertiesStackStatic> getPropertiesStackStatic() {
         return repository.listAll();
     }
 
     @Query("getPropertiesStackStaticByLabel")
-    public List<PropertiesStackStatic> getPropertiesStackStaticByLabel(String label) {
+    @Description("Fetches a list of static properties by label")
+    public List<PropertiesStackStatic> getPropertiesStackStaticByLabel(
+            @Name("label")
+            @Description("The label of the Property")
+            String label) {
         return repository.findByPropertyLabel(label);
     }
 
     @Query("getPropertiesStackStaticPaged")
+    @Description("Fetches a paginated list of static properties")
     public List<PropertiesStackStatic> getPropertiesStackStaticPaged(
-            @Description("Page number to fetch") int page,
-            @Description("Number of items per page") int size){
+            @Name("Page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.") int page,
+            @Name("Size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.") int size){
         return repository.findByPage(page, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierAuthorityResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierAuthorityResource.java
@@ -2,9 +2,7 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.inject.Inject;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierAuthority;
 import org.grnet.knowledgebase.api.repository.ResolvedIdentifierAuthorityRepository;
 
@@ -18,19 +16,29 @@ public class ResolvedIdentifierAuthorityResource {
     ResolvedIdentifierAuthorityRepository repository;
 
     @Query("getResolvedIdentifierAuthorities")
+    @Description("Fetches resolved identifier authority ")
     public List<ResolvedIdentifierAuthority> getResolvedIdentifierAuthorities() {
         return repository.listAll();
     }
 
     @Query("getResolvedIdentifierAuthoritiesByLabel")
-    public List<ResolvedIdentifierAuthority> getResolvedIdentifierAuthoritiesByLabel(String label) {
+    @Description("Fetches a list of resolved identifier authorities by label")
+    public List<ResolvedIdentifierAuthority> getResolvedIdentifierAuthoritiesByLabel(
+            @Name("label")
+            @Description("The label of the actor: Authority")
+            String label) {
         return repository.findByAuthorityLabel(label);
     }
 
     @Query("getResolvedIdentifierAuthoritiesPaged")
+    @Description("Fetches a paginated list of resolved identifier authorities")
     public List<ResolvedIdentifierAuthority> getResolvedIdentifierAuthoritiesPaged(
-            @Description("Page number to fetch") int page,
-            @Description("Number of items per page") int size){
+            @Name("Page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.") int page,
+            @Name("Size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.") int size){
         return repository.findByPage(page, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierMPAResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierMPAResource.java
@@ -1,12 +1,10 @@
 package org.grnet.knowledgebase.api.graphql;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Query;
-import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierProvider;
-import org.grnet.knowledgebase.api.repository.ResolvedIdentifierProviderRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.graphql.*;
+import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierMPA;
+import org.grnet.knowledgebase.api.repository.ResolvedIdentifierMPARepository;
 
 import java.util.List;
 
@@ -15,22 +13,47 @@ import java.util.List;
 public class ResolvedIdentifierMPAResource {
 
     @Inject
-    ResolvedIdentifierProviderRepository repository;
+    ResolvedIdentifierMPARepository repository;
 
-    @Query("getResolvedIdentifierProviders")
-    public List<ResolvedIdentifierProvider> getResolvedIdentifierProviders() {
+    /**
+     * 📄 Retrieves all Resolved Identifier MPAs.
+     * @return List of all MPAs.
+     */
+    @Query("getResolvedIdentifierMPAs")
+    @Description("Fetch all resolved identifier mpas")
+    public List<ResolvedIdentifierMPA> getResolvedIdentifierMPAs() {
         return repository.listAll();
     }
 
-    @Query("getResolvedIdentifierProvidersByLabel")
-    public List<ResolvedIdentifierProvider> getResolvedIdentifierProvidersByLabel(String providerLabel) {
-        return repository.find("labelProvider", providerLabel).list();
+    /**
+     * Finds MPAs by label.
+     * @param labelMPA The label of the MPA (e.g., "DataCite").
+     * @return List of MPAs matching the label.
+     */
+    @Query("getResolvedIdentifierMPAsByLabel")
+    @Description("Fetches a list of resolved identifier MPAs by label")
+    public List<ResolvedIdentifierMPA> getResolvedIdentifierMPAsByLabel(
+            @Name("label")
+            @Description("The label of the MPA (Multi-Provider-Agency)")
+            String labelMPA) {
+        return repository.findByLabel(labelMPA);
     }
 
-    @Query("getResolvedIdentifierProvidersPaged")
-    public List<ResolvedIdentifierProvider> getResolvedIdentifierProvidersPaged(
-            @Description("Page number to fetch") int page,
-            @Description("Number of items per page") int size) {
+    /**
+     * Retrieves a paginated list of MPAs.
+     * @param page The page number (starting from 0).
+     * @param size The number of records per page.
+     * @return A paginated list of MPAs.
+     */
+    @Query("getResolvedIdentifierMPAsPaged")
+    @Description("Fetches a paginated list of resolved identifier MPAs")
+    public List<ResolvedIdentifierMPA> getResolvedIdentifierMPAsPaged(
+            @Name("Page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.") int page,
+            @Name("Size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.") int size){
         return repository.findByPage(page, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierProviderResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierProviderResource.java
@@ -1,12 +1,10 @@
 package org.grnet.knowledgebase.api.graphql;
 
-import jakarta.inject.Inject;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Query;
-import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierMPA;
-import org.grnet.knowledgebase.api.repository.ResolvedIdentifierMPARepository;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.graphql.*;
+import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierProvider;
+import org.grnet.knowledgebase.api.repository.ResolvedIdentifierProviderRepository;
 
 import java.util.List;
 
@@ -15,37 +13,32 @@ import java.util.List;
 public class ResolvedIdentifierProviderResource {
 
     @Inject
-    ResolvedIdentifierMPARepository repository;
+    ResolvedIdentifierProviderRepository repository;
 
-    /**
-     * 📄 Retrieves all Resolved Identifier MPAs.
-     * @return List of all MPAs.
-     */
-    @Query("getResolvedIdentifierMPAs")
-    public List<ResolvedIdentifierMPA> getResolvedIdentifierMPAs() {
+    @Query("getResolvedIdentifierProviders")
+    @Description("Fetch all resolved identifier provider")
+    public List<ResolvedIdentifierProvider> getResolvedIdentifierProviders() {
         return repository.listAll();
     }
 
-    /**
-     * Finds MPAs by label.
-     * @param labelMPA The label of the MPA (e.g., "DataCite").
-     * @return List of MPAs matching the label.
-     */
-    @Query("getResolvedIdentifierMPAsByLabel")
-    public List<ResolvedIdentifierMPA> getResolvedIdentifierMPAsByLabel(String labelMPA) {
-        return repository.findByLabel(labelMPA);
+    @Query("getResolvedIdentifierProvidersByLabel")
+    @Description("Fetches a list of resolved identifier providers by label")
+    public List<ResolvedIdentifierProvider> getResolvedIdentifierProvidersByLabel(
+            @Name("label")
+            @Description("The label of the actor: Provider")
+            String labelProvider) {
+        return repository.find("labelProvider", labelProvider).list();
     }
 
-    /**
-     * Retrieves a paginated list of MPAs.
-     * @param page The page number (starting from 0).
-     * @param size The number of records per page.
-     * @return A paginated list of MPAs.
-     */
-    @Query("getResolvedIdentifierMPAsPaged")
-    public List<ResolvedIdentifierMPA> getResolvedIdentifierMPAsPaged(
-            @Description("Page number to fetch") int page,
-            @Description("Number of items per page") int size) {
+    @Query("getResolvedIdentifierProvidersPaged")
+    @Description("Fetches a paginated list of resolved identifier providers")
+    public List<ResolvedIdentifierProvider> getResolvedIdentifierProvidersPaged(
+            @Name("Page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.") int page,
+            @Name("Size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.") int size){
         return repository.findByPage(page, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierSchemeResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierSchemeResource.java
@@ -2,9 +2,7 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierScheme;
 import org.grnet.knowledgebase.api.repository.ResolvedIdentifierSchemeRepository;
 
@@ -18,19 +16,29 @@ public class ResolvedIdentifierSchemeResource {
     ResolvedIdentifierSchemeRepository repository;
 
     @Query("getResolvedIdentifierSchemes")
+    @Description("Fetch all resolved identifier schemes")
     public List<ResolvedIdentifierScheme> getResolvedIdentifierSchemes() {
         return repository.listAll();
     }
 
     @Query("getResolvedIdentifierSchemesByLabel")
-    public List<ResolvedIdentifierScheme> getResolvedIdentifierSchemesByLabel(String label) {
+    @Description("Fetches a list of resolved identifier scheme by label")
+    public List<ResolvedIdentifierScheme> getResolvedIdentifierSchemesByLabel(
+            @Name("label")
+            @Description("The label of the actor: Scheme")
+            String label) {
         return repository.findBySchemeLabel(label);
     }
 
     @Query("getResolvedIdentifierSchemesPaged")
+    @Description("Fetches a paginated list of resolved identifier schemes")
     public List<ResolvedIdentifierScheme> getResolvedIdentifierSchemesPaged(
-            @Description("Page number to fetch") int page,
-            @Description("Number of items per page") int size){
+            @Name("Page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.") int page,
+            @Name("Size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.") int size){
         return repository.findByPage(page, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierStackResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierStackResource.java
@@ -2,9 +2,7 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierStack;
 import org.grnet.knowledgebase.api.repository.ResolvedIdentifierStackRepository;
 
@@ -18,34 +16,55 @@ public class ResolvedIdentifierStackResource {
     ResolvedIdentifierStackRepository repository;
 
     @Query("getResolvedIdentifierStack")
+    @Description("Fetches resolved identifier stack ")
     public List<ResolvedIdentifierStack> getResolvedIdentifierStack() {
         return repository.listAll();
     }
 
     @Query("getResolvedIdentifierStackByLabel")
-    public List<ResolvedIdentifierStack> getResolvedIdentifierStackByLabel(String label) {
+    @Description("Fetches a list of resolved identifier stacks by Label")
+    public List<ResolvedIdentifierStack> getResolvedIdentifierStackByLabel(
+            @Name("label")
+            @Description("The label of the actor")
+            String label) {
         return repository.findByStackLabel(label);
     }
 
     @Query("getResolvedIdentifierStackByActor")
-    public List<ResolvedIdentifierStack> getResolvedIdentifierStackByActor(String actor) {
-        return repository.findByActor(actor);
+    @Description("Fetches a list of resolved identifier stacks by Actor")
+    public List<ResolvedIdentifierStack> getResolvedIdentifierStackByActor(
+            @Name("actor")
+            @Description("The name of the actor")
+            String actorName) {
+        return repository.findByActor(actorName);
     }
 
     @Query("getResolvedIdentifierStackByLabelIdentifier")
-    public List<ResolvedIdentifierStack> getResolvedIdentifierStackByLabelIdentifier(String labelIdentifier) {
+    @Description("Fetches a list of resolved identifier stacks by Identifiers Label")
+    public List<ResolvedIdentifierStack> getResolvedIdentifierStackByLabelIdentifier(
+            @Name("label")
+            @Description("The label of the Identifier")
+            String labelIdentifier) {
         return repository.findByLabelIdentifier(labelIdentifier);
     }
 
     @Query("searchResolvedIdentifierStack")
-    public List<ResolvedIdentifierStack> searchResolvedIdentifierStack(String search) {
+    @Description("Fetches a list of resolved identifier stacks by search")
+    public List<ResolvedIdentifierStack> searchResolvedIdentifierStack(
+            @Name("search")
+            @Description("Search by actor, labelIdentifier, label") String search) {
         return repository.searchByKeyword(search);
     }
 
     @Query("getResolvedIdentifierStackPaged")
+    @Description("Fetches a paginated list of resolved identifier Stack")
     public List<ResolvedIdentifierStack> getResolvedIdentifierStackPaged(
-            @Description("Page number to fetch") int page,
-            @Description("Number of items per page") int size){
+            @Name("Page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.") int page,
+            @Name("Size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.") int size){
         return repository.findByPage(page, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierStandardResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierStandardResource.java
@@ -2,9 +2,7 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierStandard;
 import org.grnet.knowledgebase.api.repository.ResolvedIdentifierStandardRepository;
 
@@ -18,19 +16,29 @@ public class ResolvedIdentifierStandardResource {
     ResolvedIdentifierStandardRepository repository;
 
     @Query("getResolvedIdentifierStandards")
+    @Description("Fetches resolved identifier standard ")
     public List<ResolvedIdentifierStandard> getResolvedIdentifierStandards() {
         return repository.listAll();
     }
 
     @Query("getResolvedIdentifierStandardsByLabel")
-    public List<ResolvedIdentifierStandard> getResolvedIdentifierStandardsByLabel(String label) {
+    @Description("Fetches resolved identifier standard from the database by label.")
+    public List<ResolvedIdentifierStandard> getResolvedIdentifierStandardsByLabel(
+            @Name("label")
+            @Description("The label of the actor: Standard")
+            String label) {
         return repository.findByStandardLabel(label);
     }
 
     @Query("getResolvedIdentifierStandardsPaged")
+    @Description("Fetches a paginated list of resolved identifier standard")
     public List<ResolvedIdentifierStandard> getResolvedIdentifierStandardsPaged(
-            @Description("Page number to fetch") int page,
-            @Description("Number of items per page") int size){
+            @Name("Page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.") int page,
+            @Name("Size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.") int size){
         return repository.findByPage(page, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/PropertiesStackCombinedRepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/PropertiesStackCombinedRepository.java
@@ -13,6 +13,10 @@ public class PropertiesStackCombinedRepository implements PanacheRepository<Prop
         return find("labelProperty", labelProperty).list();
     }
 
+    public List<PropertiesStackCombined> searchByKeyword(String search) {
+        return find("lodIDN ilike ?1 OR labelProperty ilike ?1 OR value ilike ?1", "%" + search + "%").list();
+    }
+
     public List<PropertiesStackCombined> findByPage(int page, int size) {
         return findAll().page(page, size).list();
     }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/PropertiesStackDynamicRepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/PropertiesStackDynamicRepository.java
@@ -3,7 +3,6 @@ package org.grnet.knowledgebase.api.repository;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.grnet.knowledgebase.api.entity.view.PropertiesStackDynamic;
-import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierStack;
 
 import java.util.List;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,3 +40,5 @@ kb.html.keycloak.public.client.id=frontend-service
 kb.html.keycloak.javascript.adapter=http://localhost:58080/js/keycloak.js
 
 quarkus.oidc.roles.role-claim-path=resource_access/${quarkus.oidc.client-id}/roles
+
+quarkus.smallrye-graphql.ui.always-include=true


### PR DESCRIPTION
### Filter All Views by Label
- Every structured view supports label-based filtering to improve data retrieval
```
{
  getResolvedIdentifierSchemesByLabel(label:"ArXiv Scheme") {
    actor
    label
    labelIdentifier
    lod
    lodAct
    lodIDN
  }
}
```
```
query {
  getResolvedIdentifierProvidersByLabel(label:"ARK Alliance") {
    actor
    labelIdentifier
    labelProvider
    lodAct
    lodIdn
    lodPrv
  }
}
```


### Search in Resolved Identifier Stack
- there is a search functionality within the Resolved Identifier Stack(1) and Properties Stack Combined(2), allowing searching by label, actor, or labelIdentifier on (1) and lodIDN, labelProperty and Value_ on (2)
--- 
- Search in Resolved Identifier Stack
```
{
  searchResolvedIdentifierStack(search:"Authority") {
    actor
    label
    labelIdentifier
    lod
    lodAct
    lodIDN
  }
}
```
- Search in Properties Stack Combined
```
query {
  searchPropertiesStackCombinedStack(search:"Disciplinary") {
    labelProperty
    lodIDN
    lodRelation
    value
  } 
}
```
