### PR TITLE
CAT-835 set content type-header for landing and oidc-client pages

### DIFF
--- a/src/main/java/org/grnet/knowledgebase/api/qute/HtmlTemplate.java
+++ b/src/main/java/org/grnet/knowledgebase/api/qute/HtmlTemplate.java
@@ -2,9 +2,11 @@ package org.grnet.knowledgebase.api.qute;
 
 import io.quarkus.qute.Template;
 import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.RoutingExchange;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import jakarta.ws.rs.core.MediaType;
 
 @ApplicationScoped
 public class HtmlTemplate {
@@ -34,22 +36,28 @@ public class HtmlTemplate {
     String keycloakServerJavascriptAdapter;
 
     @Route(path = "/", methods = Route.HttpMethod.GET)
-    public String landingPage() {
-
-        return index
+    public void landingPage(RoutingExchange ex) {
+        String html = index
                 .data("kb_oidc_client_url", apiHtmlOidcClientUrl)
                 .data("kb_documentation", apiHtmlGraphqlPlayground)
                 .render();
+
+        ex.response()
+                .putHeader("Content-Type", MediaType.TEXT_HTML)
+                .end(html);
     }
 
     @Route(path = "/oidc-client", methods = Route.HttpMethod.GET)
-    public String oidcClient() {
+    public void oidcClient(RoutingExchange ex) {
 
-        return client
+        String html = client
                 .data("keycloak_server_url", keycloakServerUrl,
                         "keycloak_server_realm", keycloakServerRealm,
                         "keycloak_server_client_id", keycloakServerClientId,
                         "keycloak_server_javascript_adapter", keycloakServerJavascriptAdapter)
                 .render();
+        ex.response()
+                .putHeader("Content-Type", MediaType.TEXT_HTML)
+                .end(html);
     }
 }


### PR DESCRIPTION
### Issue
Landing and oidc-client page calls don't set `Content-Type:text/html`. This causes issues in production environments, where the `X-Content-Type-Options: nosniff` header is used for security in order to instruct the browser to rely exclusively on the `Content-Type` header for interpretation and not on the file content it self. Thus the web page is rendered as simple text (code)

### Fix
Set the header `Content-Type: text/html` for the calls that render the landing page and the oidc-client. Since project uses reactive routes instead of RestEasy we can't rely on the `@Produces` annotation. Thus we use `RoutingExchange` to set up the header properly
