### PR TITLE
CAT-820 [KB] API Queries & Documentation (add default values)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#4](https://github.com/FC4E-CAT/fc4e-cat-api-kb/pull/4) CAT-826: [KB] Database Setup & Implement Example Views
 - [#6](https://github.com/FC4E-CAT/fc4e-cat-api-kb/pull/6) CAT-795: Fetch Data via filter
 - [#8](https://github.com/FC4E-CAT/fc4e-cat-api-kb/pull/8) CAT-794: [KB] Fetch Data by ID for Entities and Structured Views
+- [#11](https://github.com/FC4E-CAT/fc4e-cat-api-kb/pull/11/)CAT-820: [KB] API Queries & Documentation (add default values)
 
 
 ### Fix

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/AuthorityResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/AuthorityResource.java
@@ -1,13 +1,10 @@
 package org.grnet.knowledgebase.api.graphql;
 
-import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Name;
-import org.eclipse.microprofile.graphql.Query;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.Authority;
-import org.grnet.knowledgebase.api.entity.relation.ManagerProvider;
 import org.grnet.knowledgebase.api.repository.AuthorityRepository;
 
 import java.util.List;
@@ -19,16 +16,32 @@ public class AuthorityResource {
     AuthorityRepository repository;
 
     @Query("getAuthorities")
-    @Description("Get All Authorities")
+    @Description("Fetches All Authorities")
     public List<Authority> getAuthorities() {
         return repository.listAll();
     }
 
     @Query("getAuthorityById")
-    @Description("Fetches a paginated list of identifiers")
+    @Description("Fetches an Authority by Id")
     public Authority getAuthorityById(
             @Name("id")
+            @DefaultValue("pid_graph:00C7B7CF")
             @Description("The id of the authority") String id) {
         return repository.findById(id);
+    }
+
+    @Query("getAuthorityByPage")
+    @Description("Fetches a paginated list of Authorities")
+    public List<Authority> getPaginatedAuthorities(
+            @Name("page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/IdentifierResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/IdentifierResource.java
@@ -1,13 +1,10 @@
 package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Name;
-import org.eclipse.microprofile.graphql.Query;
-import org.grnet.knowledgebase.api.entity.Authority;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.Identifier;
-import org.grnet.knowledgebase.api.repository.AuthorityRepository;
 import org.grnet.knowledgebase.api.repository.IdentifierRepository;
 
 import java.util.List;
@@ -19,16 +16,32 @@ public class IdentifierResource {
     IdentifierRepository repository;
 
     @Query("getIdentifiers")
-    @Description("Get All Identifiers")
+    @Description("Fetches All Identifiers")
     public List<Identifier> getIdentifiers() {
         return repository.listAll();
     }
 
     @Query("getIdentifierById")
-    @Description("Fetches a paginated list of identifiers")
+    @Description("Fetches an Identifier by Id")
     public Identifier getIdentifierById(
             @Name("id")
+            @DefaultValue("pid_graph:03A715EA1")
             @Description("The id of the identifier") String id) {
         return repository.findById(id);
+    }
+
+    @Query("getIdentifiersByPage")
+    @Description("Fetches a paginated list of identifiers")
+    public List<Identifier> getPaginatedIdentifiers(
+            @Name("page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/MPAResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/MPAResource.java
@@ -1,13 +1,10 @@
 package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Name;
-import org.eclipse.microprofile.graphql.Query;
-import org.grnet.knowledgebase.api.entity.Authority;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.MPA;
-import org.grnet.knowledgebase.api.repository.AuthorityRepository;
 import org.grnet.knowledgebase.api.repository.MPARepository;
 
 import java.util.List;
@@ -25,10 +22,27 @@ public class MPAResource {
     }
 
     @Query("getMPAById")
-    @Description("Fetches a paginated list of MPAs")
+    @Description("Fetches a MPA by Id")
     public MPA getMPAById(
             @Name("id")
+            @DefaultValue("pid_graph:70E2C260")
             @Description("The id of the MPA") String id) {
         return repository.findById(id);
+    }
+
+
+    @Query("getMPAsByPage")
+    @Description("Fetches a paginated list of MPA")
+    public List<MPA> getPaginatedMPAs(
+            @Name("page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ManagerProviderResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ManagerProviderResource.java
@@ -1,9 +1,7 @@
 package org.grnet.knowledgebase.api.graphql;
 
-import io.quarkus.panache.common.Page;
 import jakarta.annotation.security.RolesAllowed;
 import org.eclipse.microprofile.graphql.*;
-import org.grnet.knowledgebase.api.entity.Identifier;
 import org.grnet.knowledgebase.api.entity.Manager;
 import org.grnet.knowledgebase.api.entity.relation.ManagerProvider;
 
@@ -13,33 +11,16 @@ import java.util.List;
 public class ManagerProviderResource {
 
     @Query("allManagerProviders")
-    @Description("Get All Manager Providers")
+    @Description("Fetches All Manager Providers")
     @RolesAllowed({"admin"})
     public List<ManagerProvider> getAllManagerProviders() {
         return ManagerProvider.listAll();
     }
 
     @Query("managers")
-    @Description("Get All Managers")
+    @Description("Fetches All Managers")
     @RolesAllowed({"user"})
     public List<Manager> getAllManagers() {
         return Manager.listAll();
-    }
-
-    @Query("identifiers")
-    @Description("Fetches a paginated list of identifiers")
-    public List<Identifier> getPaginatedIdentifiers(
-            @Name("page")
-            @Description("Page number to fetch")
-            @DefaultValue("1")
-            int page,
-            @Name("size")
-            @Description("Number of items per page")
-            @DefaultValue("10")
-            int size) {
-        return Identifier
-                .findAll()
-                .page(Page.of(page, size))
-                .list();
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ManagerResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ManagerResource.java
@@ -1,11 +1,12 @@
 package org.grnet.knowledgebase.api.graphql;
 
+import io.quarkus.panache.common.Page;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Name;
-import org.eclipse.microprofile.graphql.Query;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.Authority;
+import org.grnet.knowledgebase.api.entity.Identifier;
 import org.grnet.knowledgebase.api.entity.Manager;
 import org.grnet.knowledgebase.api.repository.AuthorityRepository;
 import org.grnet.knowledgebase.api.repository.ManagerRepository;
@@ -25,10 +26,26 @@ public class ManagerResource {
     }
 
     @Query("getManagerById")
-    @Description("Fetches a paginated list of managers")
+    @Description("Fetches a Manager by Id")
     public Manager getManagerById(
             @Name("id")
+            @DefaultValue("pid_graph:2FBC5B5F")
             @Description("The id of the manager") String id) {
         return repository.findById(id);
+    }
+
+    @Query("getManagerByPage")
+    @Description("Fetches a paginated list of Managers")
+    public List<Manager> getPaginatedManagers(
+            @Name("page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/PropertiesStackCombinedResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/PropertiesStackCombinedResource.java
@@ -2,8 +2,9 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.eclipse.microprofile.graphql.*;
-import org.grnet.knowledgebase.api.entity.Authority;
 import org.grnet.knowledgebase.api.entity.view.PropertiesStackCombined;
 import org.grnet.knowledgebase.api.repository.PropertiesStackCombinedRepository;
 
@@ -23,10 +24,11 @@ public class PropertiesStackCombinedResource {
     }
 
     @Query("getPropertiesStackCombinedById")
-    @Description("Fetches a paginated list of identifiers")
-    public PropertiesStackCombined getAuthorityById(
+    @Description("Fetches a Property Stack Combination by Id")
+    public PropertiesStackCombined getPropertyStackCombinedById(
             @Name("id")
-            @Description("The id of the authority") String id) {
+            @DefaultValue("pid_graph:D9D0AD30")
+            @Description("The id of the identifier") String id) {
         return repository.findById(id);
     }
 
@@ -34,8 +36,8 @@ public class PropertiesStackCombinedResource {
     @Description("Fetches a list of combined (static, dynamic) properties by label")
     public List<PropertiesStackCombined> getPropertiesStackCombinedByLabel(
             @Name("label")
-            @Description("The label of the Property")
-            String label) {
+            @DefaultValue("Status")
+            @Description("The label of the Property") String label) {
         return repository.findByPropertyLabel(label);
     }
 
@@ -43,19 +45,23 @@ public class PropertiesStackCombinedResource {
     @Description("Fetches a list of properties stacks combined by search")
     public List<PropertiesStackCombined> searchPropertiesStackCombined(
             @Name("search")
-            @Description("Search by lodIDN, labelIdentifier, value") String search) {
+            @DefaultValue("hasProperty")
+            @Description("Search by labelProperty, lodIDN, labelIdentifier, value") String search) {
         return repository.searchByKeyword(search);
     }
 
     @Query("getPropertiesStackCombinedPaged")
     @Description("Fetches a paginated list of the combined (static, dynamic) properties")
-    public List<PropertiesStackCombined> getPropertiesStackCombinedPaged(
-            @Name("Page")
+    public List<PropertiesStackCombined> getPaginatedPropertiesStackCombines(
+            @Name("page")
             @DefaultValue("1")
-            @Description("Indicates the page number. Page number must be >= 1.") int page,
-            @Name("Size")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
             @DefaultValue("10")
-            @Description("Page size must be between 1 and 100.") int size){
-        return repository.findByPage(page, size);
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/PropertiesStackDynamicResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/PropertiesStackDynamicResource.java
@@ -2,6 +2,8 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.PropertiesStackDynamic;
 import org.grnet.knowledgebase.api.repository.PropertiesStackDynamicRepository;
@@ -25,20 +27,23 @@ public class PropertiesStackDynamicResource {
     @Description("Fetches a list of dynamic properties by label")
     public List<PropertiesStackDynamic> getPropertiesStackDynamicByLabel(
             @Name("label")
-            @Description("The label of the Property")
-            String label) {
+            @DefaultValue("Managers")
+            @Description("The label of the Property") String label) {
         return repository.findByPropertyLabel(label);
     }
 
     @Query("getPropertiesStackDynamicPaged")
     @Description("Fetches a paginated list of dynamic properties")
-    public List<PropertiesStackDynamic> getPropertiesStackDynamicPaged(
+    public List<PropertiesStackDynamic> getPaginatedPropertiesStackDynamic(
             @Name("page")
             @DefaultValue("1")
-            @Description("Indicates the page number. Page number must be >= 1.") int page,
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
             @Name("size")
             @DefaultValue("10")
-            @Description("Page size must be between 1 and 100.") int size){
-        return repository.findByPage(page, size);
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/PropertiesStackStaticResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/PropertiesStackStaticResource.java
@@ -2,6 +2,8 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.PropertiesStackStatic;
 import org.grnet.knowledgebase.api.repository.PropertiesStackStaticRepository;
@@ -25,20 +27,23 @@ public class PropertiesStackStaticResource {
     @Description("Fetches a list of static properties by label")
     public List<PropertiesStackStatic> getPropertiesStackStaticByLabel(
             @Name("label")
-            @Description("The label of the Property")
-            String label) {
+            @DefaultValue("Resolution Topology")
+            @Description("The label of the Property") String label) {
         return repository.findByPropertyLabel(label);
     }
 
     @Query("getPropertiesStackStaticPaged")
     @Description("Fetches a paginated list of static properties")
-    public List<PropertiesStackStatic> getPropertiesStackStaticPaged(
-            @Name("Page")
+    public List<PropertiesStackStatic> getPaginatedPropertiesStackStatic(
+            @Name("page")
             @DefaultValue("1")
-            @Description("Indicates the page number. Page number must be >= 1.") int page,
-            @Name("Size")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
             @DefaultValue("10")
-            @Description("Page size must be between 1 and 100.") int size){
-        return repository.findByPage(page, size);
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ProviderResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ProviderResource.java
@@ -1,13 +1,10 @@
 package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Name;
-import org.eclipse.microprofile.graphql.Query;
-import org.grnet.knowledgebase.api.entity.Authority;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.Provider;
-import org.grnet.knowledgebase.api.repository.AuthorityRepository;
 import org.grnet.knowledgebase.api.repository.ProviderRepository;
 
 import java.util.List;
@@ -25,10 +22,26 @@ public class ProviderResource {
     }
 
     @Query("getProviderById")
-    @Description("Fetches a paginated list of providers")
+    @Description("Fetches a Provider by Id")
     public Provider getProvidersById(
             @Name("id")
+            @DefaultValue("pid_graph:3C391CE0")
             @Description("The id of the provider") String id) {
         return repository.findById(id);
+    }
+
+    @Query("getProvidersByPage")
+    @Description("Fetches a paginated list of identifiers")
+    public List<Provider> getPaginatedProviders(
+            @Name("page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierAuthorityResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierAuthorityResource.java
@@ -2,6 +2,8 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.inject.Inject;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierAuthority;
 import org.grnet.knowledgebase.api.repository.ResolvedIdentifierAuthorityRepository;
@@ -25,20 +27,23 @@ public class ResolvedIdentifierAuthorityResource {
     @Description("Fetches a list of resolved identifier authorities by label")
     public List<ResolvedIdentifierAuthority> getResolvedIdentifierAuthoritiesByLabel(
             @Name("label")
-            @Description("The label of the actor: Authority")
-            String label) {
+            @DefaultValue("DONA")
+            @Description("The label of the Authority") String label) {
         return repository.findByAuthorityLabel(label);
     }
 
     @Query("getResolvedIdentifierAuthoritiesPaged")
     @Description("Fetches a paginated list of resolved identifier authorities")
-    public List<ResolvedIdentifierAuthority> getResolvedIdentifierAuthoritiesPaged(
-            @Name("Page")
+    public List<ResolvedIdentifierAuthority> getPaginatedResolvedIdentifierAuthorities(
+            @Name("page")
             @DefaultValue("1")
-            @Description("Indicates the page number. Page number must be >= 1.") int page,
-            @Name("Size")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
             @DefaultValue("10")
-            @Description("Page size must be between 1 and 100.") int size){
-        return repository.findByPage(page, size);
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierMPAResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierMPAResource.java
@@ -2,6 +2,8 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.inject.Inject;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierMPA;
 import org.grnet.knowledgebase.api.repository.ResolvedIdentifierMPARepository;
@@ -27,16 +29,16 @@ public class ResolvedIdentifierMPAResource {
 
     /**
      * Finds MPAs by label.
-     * @param labelMPA The label of the MPA (e.g., "DataCite").
+     * @param labelIdentifier The label of the Identifier
      * @return List of MPAs matching the label.
      */
     @Query("getResolvedIdentifierMPAsByLabel")
     @Description("Fetches a list of resolved identifier MPAs by label")
     public List<ResolvedIdentifierMPA> getResolvedIdentifierMPAsByLabel(
             @Name("label")
-            @Description("The label of the MPA (Multi-Provider-Agency)")
-            String labelMPA) {
-        return repository.findByLabel(labelMPA);
+            @DefaultValue("ORCID")
+            @Description("The label of the Resolved Identifier") String labelIdentifier) {
+        return repository.findByLabel(labelIdentifier);
     }
 
     /**
@@ -47,13 +49,16 @@ public class ResolvedIdentifierMPAResource {
      */
     @Query("getResolvedIdentifierMPAsPaged")
     @Description("Fetches a paginated list of resolved identifier MPAs")
-    public List<ResolvedIdentifierMPA> getResolvedIdentifierMPAsPaged(
-            @Name("Page")
+    public List<ResolvedIdentifierMPA> getPaginatedResolvedIdentifierMPAs(
+            @Name("page")
             @DefaultValue("1")
-            @Description("Indicates the page number. Page number must be >= 1.") int page,
-            @Name("Size")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
             @DefaultValue("10")
-            @Description("Page size must be between 1 and 100.") int size){
-        return repository.findByPage(page, size);
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierProviderResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierProviderResource.java
@@ -2,6 +2,8 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierProvider;
 import org.grnet.knowledgebase.api.repository.ResolvedIdentifierProviderRepository;
@@ -25,20 +27,23 @@ public class ResolvedIdentifierProviderResource {
     @Description("Fetches a list of resolved identifier providers by label")
     public List<ResolvedIdentifierProvider> getResolvedIdentifierProvidersByLabel(
             @Name("label")
-            @Description("The label of the actor: Provider")
-            String labelProvider) {
+            @DefaultValue("arXiv.org")
+            @Description("The label of the provider") String labelProvider) {
         return repository.find("labelProvider", labelProvider).list();
     }
 
     @Query("getResolvedIdentifierProvidersPaged")
     @Description("Fetches a paginated list of resolved identifier providers")
-    public List<ResolvedIdentifierProvider> getResolvedIdentifierProvidersPaged(
-            @Name("Page")
+    public List<ResolvedIdentifierProvider> getPaginatedResolvedIdentifierProviders(
+            @Name("page")
             @DefaultValue("1")
-            @Description("Indicates the page number. Page number must be >= 1.") int page,
-            @Name("Size")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
             @DefaultValue("10")
-            @Description("Page size must be between 1 and 100.") int size){
-        return repository.findByPage(page, size);
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierSchemeResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierSchemeResource.java
@@ -2,6 +2,8 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierScheme;
 import org.grnet.knowledgebase.api.repository.ResolvedIdentifierSchemeRepository;
@@ -25,20 +27,23 @@ public class ResolvedIdentifierSchemeResource {
     @Description("Fetches a list of resolved identifier scheme by label")
     public List<ResolvedIdentifierScheme> getResolvedIdentifierSchemesByLabel(
             @Name("label")
-            @Description("The label of the actor: Scheme")
-            String label) {
+            @DefaultValue("URN:NBN")
+            @Description("The label of the Scheme") String label) {
         return repository.findBySchemeLabel(label);
     }
 
     @Query("getResolvedIdentifierSchemesPaged")
     @Description("Fetches a paginated list of resolved identifier schemes")
-    public List<ResolvedIdentifierScheme> getResolvedIdentifierSchemesPaged(
-            @Name("Page")
+    public List<ResolvedIdentifierScheme> getPaginatedResolvedIdentifierSchemes(
+            @Name("page")
             @DefaultValue("1")
-            @Description("Indicates the page number. Page number must be >= 1.") int page,
-            @Name("Size")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
             @DefaultValue("10")
-            @Description("Page size must be between 1 and 100.") int size){
-        return repository.findByPage(page, size);
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierStackResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierStackResource.java
@@ -2,8 +2,9 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.eclipse.microprofile.graphql.*;
-import org.grnet.knowledgebase.api.entity.view.PropertiesStackCombined;
 import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierStack;
 import org.grnet.knowledgebase.api.repository.ResolvedIdentifierStackRepository;
 
@@ -23,10 +24,11 @@ public class ResolvedIdentifierStackResource {
     }
 
     @Query("getResolvedIdentifierStackById")
-    @Description("Fetches a paginated list of identifiers")
-    public ResolvedIdentifierStack getAuthorityById(
+    @Description("Fetches a Resolved Identifier Stack by Id")
+    public ResolvedIdentifierStack getResolvedIdentifierStackById(
             @Name("id")
-            @Description("The id of the authority") String id) {
+            @DefaultValue("pid_graph:998B7874")
+            @Description("The id of the Identifier") String id) {
         return repository.findById(id);
     }
 
@@ -34,8 +36,8 @@ public class ResolvedIdentifierStackResource {
     @Description("Fetches a list of resolved identifier stacks by Label")
     public List<ResolvedIdentifierStack> getResolvedIdentifierStackByLabel(
             @Name("label")
-            @Description("The label of the actor")
-            String label) {
+            @DefaultValue("DONA")
+            @Description("The label of the identifier") String label) {
         return repository.findByStackLabel(label);
     }
 
@@ -43,8 +45,8 @@ public class ResolvedIdentifierStackResource {
     @Description("Fetches a list of resolved identifier stacks by Actor")
     public List<ResolvedIdentifierStack> getResolvedIdentifierStackByActor(
             @Name("actor")
-            @Description("The name of the actor")
-            String actorName) {
+            @DefaultValue("Authority")
+            @Description("The name of the actor") String actorName) {
         return repository.findByActor(actorName);
     }
 
@@ -52,8 +54,8 @@ public class ResolvedIdentifierStackResource {
     @Description("Fetches a list of resolved identifier stacks by Identifiers Label")
     public List<ResolvedIdentifierStack> getResolvedIdentifierStackByLabelIdentifier(
             @Name("label")
-            @Description("The label of the Identifier")
-            String labelIdentifier) {
+            @DefaultValue("DOI")
+            @Description("The label of the Identifier") String labelIdentifier) {
         return repository.findByLabelIdentifier(labelIdentifier);
     }
 
@@ -61,19 +63,23 @@ public class ResolvedIdentifierStackResource {
     @Description("Fetches a list of resolved identifier stacks by search")
     public List<ResolvedIdentifierStack> searchResolvedIdentifierStack(
             @Name("search")
+            @DefaultValue("MPA")
             @Description("Search by actor, labelIdentifier, label") String search) {
         return repository.searchByKeyword(search);
     }
 
     @Query("getResolvedIdentifierStackPaged")
     @Description("Fetches a paginated list of resolved identifier Stack")
-    public List<ResolvedIdentifierStack> getResolvedIdentifierStackPaged(
-            @Name("Page")
+    public List<ResolvedIdentifierStack> getPaginatedResolvedIdentifierStack(
+            @Name("page")
             @DefaultValue("1")
-            @Description("Indicates the page number. Page number must be >= 1.") int page,
-            @Name("Size")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
             @DefaultValue("10")
-            @Description("Page size must be between 1 and 100.") int size){
-        return repository.findByPage(page, size);
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierStandardResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/ResolvedIdentifierStandardResource.java
@@ -2,6 +2,8 @@ package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.view.ResolvedIdentifierStandard;
 import org.grnet.knowledgebase.api.repository.ResolvedIdentifierStandardRepository;
@@ -25,20 +27,23 @@ public class ResolvedIdentifierStandardResource {
     @Description("Fetches resolved identifier standard from the database by label.")
     public List<ResolvedIdentifierStandard> getResolvedIdentifierStandardsByLabel(
             @Name("label")
-            @Description("The label of the actor: Standard")
-            String label) {
+            @DefaultValue("Bibcode Published Schema")
+            @Description("The label of the Standard") String label) {
         return repository.findByStandardLabel(label);
     }
 
     @Query("getResolvedIdentifierStandardsPaged")
     @Description("Fetches a paginated list of resolved identifier standard")
-    public List<ResolvedIdentifierStandard> getResolvedIdentifierStandardsPaged(
-            @Name("Page")
+    public List<ResolvedIdentifierStandard> getPaginatedResolvedIdentifierStandards(
+            @Name("page")
             @DefaultValue("1")
-            @Description("Indicates the page number. Page number must be >= 1.") int page,
-            @Name("Size")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
             @DefaultValue("10")
-            @Description("Page size must be between 1 and 100.") int size){
-        return repository.findByPage(page, size);
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/SchemeResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/SchemeResource.java
@@ -1,13 +1,10 @@
 package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Name;
-import org.eclipse.microprofile.graphql.Query;
-import org.grnet.knowledgebase.api.entity.Authority;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.Scheme;
-import org.grnet.knowledgebase.api.repository.AuthorityRepository;
 import org.grnet.knowledgebase.api.repository.SchemeRepository;
 
 import java.util.List;
@@ -25,10 +22,26 @@ public class SchemeResource {
     }
 
     @Query("getSchemeById")
-    @Description("Fetches a paginated list of schemes")
+    @Description("Fetches a Scheme by Id")
     public Scheme getSchemeById(
             @Name("id")
+            @DefaultValue("pid_graph:466E3789")
             @Description("The id of the scheme") String id) {
         return repository.findById(id);
+    }
+
+    @Query("getStandardByPage")
+    @Description("Fetches a paginated list of Scheme")
+    public List<Scheme> getPaginatedSchemes(
+            @Name("page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/graphql/StandardResource.java
+++ b/src/main/java/org/grnet/knowledgebase/api/graphql/StandardResource.java
@@ -1,13 +1,10 @@
 package org.grnet.knowledgebase.api.graphql;
 
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Name;
-import org.eclipse.microprofile.graphql.Query;
-import org.grnet.knowledgebase.api.entity.Authority;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.eclipse.microprofile.graphql.*;
 import org.grnet.knowledgebase.api.entity.Standard;
-import org.grnet.knowledgebase.api.repository.AuthorityRepository;
 import org.grnet.knowledgebase.api.repository.StandardRepository;
 
 import java.util.List;
@@ -25,10 +22,26 @@ public class StandardResource {
     }
 
     @Query("getStandardById")
-    @Description("Fetches a paginated list of identifiers")
+    @Description("Fetches a Standard by Id")
     public Standard getStandardById(
             @Name("id")
+            @DefaultValue("pid_graph:FCDAACDB")
             @Description("The id of the standard") String id) {
         return repository.findById(id);
+    }
+
+    @Query("getStandardByPage")
+    @Description("Fetches a paginated list of Standards")
+    public List<Standard> getPaginatedResource(
+            @Name("page")
+            @DefaultValue("1")
+            @Description("Indicates the page number. Page number must be >= 1.")
+            @Min(value = 1, message = "Page number must be >= 1.") int page,
+            @Name("size")
+            @DefaultValue("10")
+            @Description("Page size must be between 1 and 100.")
+            @Min(value = 1, message = "Page size must be between 1 and 100.")
+            @Max(value = 100, message = "Page size must be between 1 and 100.") int size) {
+        return repository.findByPage(page - 1, size);
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/AuthorityRepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/AuthorityRepository.java
@@ -3,7 +3,6 @@ package org.grnet.knowledgebase.api.repository;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.grnet.knowledgebase.api.entity.Authority;
-import org.grnet.knowledgebase.api.entity.view.PropertiesStackCombined;
 
 import java.util.List;
 
@@ -12,5 +11,8 @@ public class AuthorityRepository implements PanacheRepository<Authority> {
 
     public Authority findById(String lodAUT) {
         return find("lodAUT", lodAUT).firstResult();
+    }
+    public List<Authority> findByPage(int page, int size) {
+        return findAll().page(page, size).list();
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/IdentifierRepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/IdentifierRepository.java
@@ -2,13 +2,17 @@ package org.grnet.knowledgebase.api.repository;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.grnet.knowledgebase.api.entity.Authority;
 import org.grnet.knowledgebase.api.entity.Identifier;
-import org.grnet.knowledgebase.api.entity.view.PropertiesStackCombined;
+
+import java.util.List;
 
 @ApplicationScoped
 public class IdentifierRepository implements PanacheRepository<Identifier> {
     public Identifier findById(String lodIDN) {
         return find("lodIDN", lodIDN).firstResult();
+    }
+
+    public List<Identifier> findByPage(int page, int size) {
+        return findAll().page(page, size).list();
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/MPARepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/MPARepository.java
@@ -2,13 +2,16 @@ package org.grnet.knowledgebase.api.repository;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.grnet.knowledgebase.api.entity.Authority;
 import org.grnet.knowledgebase.api.entity.MPA;
-import org.grnet.knowledgebase.api.entity.view.PropertiesStackCombined;
+
+import java.util.List;
 
 @ApplicationScoped
 public class MPARepository implements PanacheRepository<MPA> {
     public MPA findById(String lodMPA) {
         return find("lodMPA", lodMPA).firstResult();
+    }
+    public List<MPA> findByPage(int page, int size) {
+        return findAll().page(page, size).list();
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/ManagerRepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/ManagerRepository.java
@@ -2,13 +2,17 @@ package org.grnet.knowledgebase.api.repository;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.grnet.knowledgebase.api.entity.Authority;
 import org.grnet.knowledgebase.api.entity.Manager;
-import org.grnet.knowledgebase.api.entity.view.PropertiesStackCombined;
+
+import java.util.List;
 
 @ApplicationScoped
 public class ManagerRepository implements PanacheRepository<Manager> {
     public Manager findById(String lodMAN) {
         return find("lodMAN", lodMAN).firstResult();
+    }
+
+    public List<Manager> findByPage(int page, int size) {
+        return findAll().page(page, size).list();
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/PropertiesStackCombinedRepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/PropertiesStackCombinedRepository.java
@@ -2,7 +2,6 @@ package org.grnet.knowledgebase.api.repository;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.grnet.knowledgebase.api.entity.Manager;
 import org.grnet.knowledgebase.api.entity.view.PropertiesStackCombined;
 
 import java.util.List;
@@ -20,10 +19,11 @@ public class PropertiesStackCombinedRepository implements PanacheRepository<Prop
     }
 
     public List<PropertiesStackCombined> searchByKeyword(String search) {
-        return find("lodIDN ilike ?1 OR labelProperty ilike ?1 OR value ilike ?1", "%" + search + "%").list();
+        return find("lodIDN ilike ?1 OR labelProperty ilike ?1 OR value ilike ?1 OR lodRelation ilike ?1", "%" + search + "%").list();
     }
 
     public List<PropertiesStackCombined> findByPage(int page, int size) {
         return findAll().page(page, size).list();
     }
+
 }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/PropertiesStackDynamicRepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/PropertiesStackDynamicRepository.java
@@ -12,7 +12,6 @@ public class PropertiesStackDynamicRepository implements PanacheRepository<Prope
     public List<PropertiesStackDynamic> findByPropertyLabel(String labelProperty) {
         return find("labelProperty", labelProperty).list();
     }
-
     public List<PropertiesStackDynamic> findByPage(int page, int size) {
         return findAll().page(page, size).list();
     }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/PropertiesStackStaticRepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/PropertiesStackStaticRepository.java
@@ -12,7 +12,6 @@ public class PropertiesStackStaticRepository implements PanacheRepository<Proper
     public List<PropertiesStackStatic> findByPropertyLabel(String labelProperty) {
         return find("labelProperty", labelProperty).list();
     }
-
     public List<PropertiesStackStatic> findByPage(int page, int size) {
         return findAll().page(page, size).list();
     }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/ProviderRepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/ProviderRepository.java
@@ -2,13 +2,18 @@ package org.grnet.knowledgebase.api.repository;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.grnet.knowledgebase.api.entity.Authority;
 import org.grnet.knowledgebase.api.entity.Provider;
-import org.grnet.knowledgebase.api.entity.view.PropertiesStackCombined;
+
+import java.util.List;
 
 @ApplicationScoped
 public class ProviderRepository implements PanacheRepository<Provider> {
     public Provider findById(String lodPRV) {
         return find("lodPRV", lodPRV).firstResult();
     }
+
+    public List<Provider> findByPage(int page, int size) {
+        return findAll().page(page, size).list();
+    }
+
 }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/ResolvedIdentifierAuthorityRepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/ResolvedIdentifierAuthorityRepository.java
@@ -12,7 +12,6 @@ public class ResolvedIdentifierAuthorityRepository implements PanacheRepository<
     public List<ResolvedIdentifierAuthority> findByAuthorityLabel(String authorityLabel) {
         return find("label", authorityLabel).list();
     }
-
     public List<ResolvedIdentifierAuthority> findByPage(int page, int size) {
         return findAll().page(page, size).list();
     }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/ResolvedIdentifierMPARepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/ResolvedIdentifierMPARepository.java
@@ -12,11 +12,11 @@ public class ResolvedIdentifierMPARepository implements PanacheRepository<Resolv
     /**
      * 🔍 Find identifiers by MPA label.
      *
-     * @param labelMpa The name of the MPA (e.g., "RAID Australia").
+     * @param labelIdentifier The name of the MPA (e.g., "RAID Australia").
      * @return A list of resolved identifiers linked to this MPA.
      */
-    public List<ResolvedIdentifierMPA> findByLabel(String labelMpa) {
-        return find("labelMPA", labelMpa).list();
+    public List<ResolvedIdentifierMPA> findByLabel(String labelIdentifier) {
+        return find("labelIdentifier", labelIdentifier).list();
     }
 
     /**

--- a/src/main/java/org/grnet/knowledgebase/api/repository/ResolvedIdentifierStandardRepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/ResolvedIdentifierStandardRepository.java
@@ -12,7 +12,6 @@ public class ResolvedIdentifierStandardRepository implements PanacheRepository<R
     public List<ResolvedIdentifierStandard> findByStandardLabel(String standardLabel) {
         return find("label", standardLabel).list();
     }
-
     public List<ResolvedIdentifierStandard> findByPage(int page, int size) {
         return findAll().page(page, size).list();
     }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/SchemeRepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/SchemeRepository.java
@@ -2,13 +2,17 @@ package org.grnet.knowledgebase.api.repository;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.grnet.knowledgebase.api.entity.Authority;
 import org.grnet.knowledgebase.api.entity.Scheme;
-import org.grnet.knowledgebase.api.entity.view.PropertiesStackCombined;
+
+import java.util.List;
 
 @ApplicationScoped
 public class SchemeRepository implements PanacheRepository<Scheme> {
     public Scheme findById(String lodSCH) {
         return find("lodSCH", lodSCH).firstResult();
+    }
+
+    public List<Scheme> findByPage(int page, int size) {
+        return findAll().page(page, size).list();
     }
 }

--- a/src/main/java/org/grnet/knowledgebase/api/repository/StandardRepository.java
+++ b/src/main/java/org/grnet/knowledgebase/api/repository/StandardRepository.java
@@ -2,13 +2,17 @@ package org.grnet.knowledgebase.api.repository;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.grnet.knowledgebase.api.entity.Authority;
 import org.grnet.knowledgebase.api.entity.Standard;
-import org.grnet.knowledgebase.api.entity.view.PropertiesStackCombined;
+
+import java.util.List;
 
 @ApplicationScoped
 public class StandardRepository implements PanacheRepository<Standard> {
     public Standard findById(String lodSTD) {
         return find("lodSTD", lodSTD).firstResult();
+    }
+
+    public List<Standard> findByPage(int page, int size) {
+        return findAll().page(page, size).list();
     }
 }


### PR DESCRIPTION
We updated the GraphQL queries in the KB API by adding default values to parameters. 

### Examples:

```    @Query("getResolvedIdentifierStackById")
    @Description("Fetches a Resolved Identifier Stack by Id")
    public ResolvedIdentifierStack getResolvedIdentifierStackById(
            @Name("id")
            @DefaultValue("pid_graph:998B7874")
            @Description("The id of the Identifier") String id) {
        return repository.findById(id);
    }
```
    
```   @Query("getPropertiesStackCombinedByLabel")
    @Description("Fetches a list of combined (static, dynamic) properties by label")
    public List<PropertiesStackCombined> getPropertiesStackCombinedByLabel(
            @Name("label")
            @DefaultValue("Status")
            @Description("The label of the Property") String label) {
        return repository.findByPropertyLabel(label);
    }
